### PR TITLE
Add xyzservices 2022.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xyzservices" %}
-{% set version = "2022.6.0" %}
+{% set version = "2022.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,34 +7,37 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1fbd37d7f725bdceefe857b3b1f8121e50a038bbae496944668c67fffd54dd0f
+  sha256: 55651961708b9a14849978b339df76008c886df7a8326308a5549bae5516260c
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
     - xyzservices.providers
     - xyzservices
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/geopandas/xyzservices
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/geopandas/xyzservices/blob/main/LICENSE
   summary: Source of XYZ tiles providers
   description: |
     xyzservices is a lightweight library providing a repository of available XYZ


### PR DESCRIPTION
Changelog: https://github.com/geopandas/xyzservices/blob/2022.9.0/CHANGELOG.md
License: https://github.com/geopandas/xyzservices/blob/main/LICENSE
Requirements: https://github.com/geopandas/xyzservices/blob/2022.9.0/setup.py

Actions:
1. Remove `noarch: python`
2. Skip `py<37`
3. Fix `python` in `host` and `run`
4. Add missing packages `setuptools` and `wheel` to `host`
5. Add `license_url`